### PR TITLE
warcraft3.info new json format

### DIFF
--- a/src/bnet_player_monitor.py
+++ b/src/bnet_player_monitor.py
@@ -77,7 +77,7 @@ class BNetPlayerMonitor(Thread):
     or_str = ' or '
     filter_str = ''
     for ip in GatewayNetMap.values():
-      filter_str += 'host ' + ip + or_str
+      filter_str += 'net ' + ip + or_str
     return filter_str[:len(filter_str) - len(or_str)]
 
   def run(self):

--- a/src/wc3info_alias_interface.py
+++ b/src/wc3info_alias_interface.py
@@ -8,13 +8,12 @@ class Wc3InfoAliasInterface:
     for entry in data:
       if entry['aka'] is None or entry['aka'] is '':
         continue
-      if entry['daily_history']['name'] == player.name:
-        alias_pat = re.compile(r'.*>(.*)</a>')
-        alias = alias_pat.match(entry['aka']).group(1)
+      if entry['aka']['aka'] == player.name:
+        alias = entry['aka']['player']['name']
     player.alias = alias
 
   def get_alias(player, gateway):
     url = 'https://warcraft3.info/stats/bnet_data?server=' + gateway
     response = requests.get(url)
     if response.status_code == requests.codes.ok:
-      Wc3InfoAliasInterface.__get_alias(player, response.json()['data'])
+      Wc3InfoAliasInterface.__get_alias(player, response.json()['ranking'])


### PR DESCRIPTION
Hi, I've seen some Exception, where the 'data' json attribute can't be parsed. I've checked the url and it seems that warcraft3.info changed its json format. this PR fixes the error.