### PR TITLE
handle webproile timeouts and also send map name

### DIFF
--- a/src/bnet_stats_scraper.py
+++ b/src/bnet_stats_scraper.py
@@ -28,8 +28,12 @@ class BNetStatsScraper:
     if gateway not in GatewayList:
       raise ValueError('Invalid Gateway')
 
-    page = urlopen('http://classic.battle.net/war3/ladder/' + GameInfo.get_game_version_str() + '-player-profile.aspx?Gateway=' + gateway + '&PlayerName=' + player.name)
-    soup = BeautifulSoup(page, 'html.parser')
-    BNetStatsScraper.__get_stat(soup, player.solo_stats, 'Solo Games')
-    BNetStatsScraper.__get_stat(soup, player.team_stats, 'Team Games')
-    BNetStatsScraper.__get_stat(soup, player.ffa_stats, 'FFA Games')
+    try:
+      url = 'http://classic.battle.net/war3/ladder/' + GameInfo.get_game_version_str() + '-player-profile.aspx?Gateway=' + gateway + '&PlayerName=' + player.name
+      page = urlopen(url, timeout=10)
+      soup = BeautifulSoup(page, 'html.parser')
+      BNetStatsScraper.__get_stat(soup, player.solo_stats, 'Solo Games')
+      BNetStatsScraper.__get_stat(soup, player.team_stats, 'Team Games')
+      BNetStatsScraper.__get_stat(soup, player.ffa_stats, 'FFA Games')
+    except:
+      player.solo_stats.wins = player.team_stats.wins = player.ffa_stats.wins = -1

--- a/src/bnet_stats_scraper.py
+++ b/src/bnet_stats_scraper.py
@@ -50,6 +50,7 @@ class BNetStatsScraper:
               player.solo_stats.wins = entry['wins']
               player.solo_stats.losses = entry['losses']
               player.solo_stats.winrate = entry['winrate']
+              player.team_stats.wins = player.ffa_stats.wins = -1
               break
       except:
         player.solo_stats.wins = player.team_stats.wins = player.ffa_stats.wins = -1

--- a/src/game_state.py
+++ b/src/game_state.py
@@ -25,6 +25,9 @@ class GameState():
   def is_in_game(self):
     return self.__read()['is_in_game'] == 1
 
+  def map_name(self):
+    return self.__read()['map_name']
+
   def open(self):
     self.shmem = mmap.mmap(-1, ObserverSharedMemory.sizeof(), "War3StatsObserverSharedMemory", access=mmap.ACCESS_READ)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import re
 import json
 import time
 
@@ -5,7 +6,6 @@ from bnet_player_monitor import BNetPlayerMonitor
 from broadcast_server import BroadcastServer
 from game_state import GameState
 from player import Player
-
 
 def obj_dict(obj):
   return obj.__dict__
@@ -52,7 +52,8 @@ def handle_game_started(server, player_list):
   send_msg(server, 'player_data', [team1, team2])
   send_msg(server, 'game_started')
 
-
+def handle_map(server, mapname):
+  send_msg(server, 'map_name', re.search(r"\(\d*\)(.*).w3", mapname).group(1).title())
 
 def main():
   player_monitor = BNetPlayerMonitor()
@@ -99,14 +100,13 @@ def main():
         # Delay a bit to allow the stat lookups to finish
         # This is more of a problem when the game loads too quick
         time.sleep(3)
-
         print('Game started')
+        handle_map(server, game_state.map_name())
         handle_game_started(server, player_monitor.get_players())
       else:
         print('Game ended')
         send_msg(server, 'game_ended')
         player_monitor.reset_players()
-
     time.sleep(1)
 
 if __name__ == "__main__":

--- a/src/player.py
+++ b/src/player.py
@@ -16,7 +16,7 @@ class Player:
     self.ffa_stats = Stats()
 
   def print(self):
-    if self.solo_stats.wins == -1 or self.team_stats.wins == -1 or self.ffa_stats.wins == -1:
+    if self.solo_stats.wins == -1 and self.team_stats.wins == -1 and self.ffa_stats.wins == -1:
       print('Can not reach battle.net webprofiles for: ')
       print('[{}] {} ({})'.format(self.id, self.name, self.race))
     else:

--- a/src/player.py
+++ b/src/player.py
@@ -16,4 +16,11 @@ class Player:
     self.ffa_stats = Stats()
 
   def print(self):
+    if self.solo_stats.wins == -1 or self.team_stats.wins == -1 or self.ffa_stats.wins == -1:
+      print('Can not reach battle.net webprofiles for: ')
+      print('[{}] {} ({})'.format(self.id, self.name, self.race))
+    else:
+      self.__print()
+
+  def __print(self):
     print('[{}] {} ({}) - Solo: W:{} L:{} ({}%) - Team: W:{} L:{} ({}%) - FFA: W:{} L:{} ({}%)'.format(self.id, self.name, self.race, self.solo_stats.wins, self.solo_stats.losses, self.solo_stats.win_percent, self.team_stats.wins, self.team_stats.losses, self.team_stats.win_percent, self.ffa_stats.wins, self.ffa_stats.losses, self.ffa_stats.win_percent))

--- a/src/wc3info_alias_interface.py
+++ b/src/wc3info_alias_interface.py
@@ -1,4 +1,3 @@
-import re
 import requests
 
 
@@ -14,6 +13,6 @@ class Wc3InfoAliasInterface:
 
   def get_alias(player, gateway):
     url = 'https://warcraft3.info/stats/bnet_data?server=' + gateway
-    response = requests.get(url)
+    response = requests.get(url, timeout=10)
     if response.status_code == requests.codes.ok:
       Wc3InfoAliasInterface.__get_alias(player, response.json()['ranking'])

--- a/tests/player_data.py
+++ b/tests/player_data.py
@@ -5,6 +5,7 @@ from player import Player
 
 p1 = Player()
 p1.id = 1
+p1.is_me = True
 p1.name = 'FollowGrubby'
 p1.alias = 'Grubby'
 p1.race = 'Orc'
@@ -29,6 +30,7 @@ p2.team_stats.win_percent = 98
 
 p3 = Player()
 p3.id = 3
+p3.is_me = True
 p3.name = 'RomanticHuman'
 p3.alias = 'ToD'
 p3.race = 'Human'
@@ -95,3 +97,17 @@ p8.solo_stats.win_percent = 0
 p8.team_stats.wins = 15
 p8.team_stats.losses = 0
 p8.team_stats.win_percent = 100
+
+p9 = Player()
+p9.id = 9
+p9.name = 'feelsHuman'
+p9.race = 'Human'
+p9.solo_stats.wins = -1
+p9.team_stats.wins = -1
+
+p10 = Player()
+p10.id = 10
+p10.name = 'feelsUndeadMan'
+p10.race = 'Undead'
+p10.solo_stats.wins = -1
+p10.team_stats.wins = -1

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -13,6 +13,7 @@ class TestRunner:
     while True:
       for m in self.matchups:
         await websocket.send(json.dumps({'type': 'game_started'}))
+        await websocket.send(json.dumps({'type': 'map_name', 'data': 'Last Refuge'}))
         await websocket.send(json.dumps({'type': 'player_data', 'data': m}, default=obj_dict))
         await asyncio.sleep(6)
         await websocket.send(json.dumps({'type': 'game_ended'}))

--- a/tests/test_1v1.py
+++ b/tests/test_1v1.py
@@ -1,7 +1,7 @@
 from player_data import *
 from runner import *
 
-matchups = [[[p1], [p2]], [[p3], [p4]], [[p5], [p6]], [[p7], [p8]]]
+matchups = [[[p1], [p2]], [[p3], [p4]], [[p5], [p6]], [[p7], [p8]], [[p9], [p10]]]
 
 runner = TestRunner(matchups)
 runner.start()


### PR DESCRIPTION
hey,

classic.battle.net has been down very often in the last time and I've seen streamer stopped using this tool because they think its broken :( so I've set a timeout (10s) and set wins to -1 so the client can handle this exception by showing "no record found" or something, a console message is printed so the user knows that the lookup failed. client code is untouched by me, because my notebook turns off on battery if I run `npm install` xd.